### PR TITLE
make `small_discriminant` const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ struct DiscriminantVTable {
     type_id: fn() -> TypeId,
 }
 
-unsafe fn as_ref<T>(this: &Discriminant) -> &core::mem::Discriminant<T> {
+const unsafe fn as_ref<T>(this: &Discriminant) -> &core::mem::Discriminant<T> {
     unsafe {
         &*if small_discriminant::<T>() {
             this.data.as_ptr().cast::<core::mem::Discriminant<T>>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ impl Discriminant {
     }
 }
 
-fn small_discriminant<T>() -> bool {
+const fn small_discriminant<T>() -> bool {
     mem::size_of::<core::mem::Discriminant<T>>() <= mem::size_of::<*const ()>()
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ struct DiscriminantVTable {
     type_id: fn() -> TypeId,
 }
 
-const unsafe fn as_ref<T>(this: &Discriminant) -> &core::mem::Discriminant<T> {
+unsafe fn as_ref<T>(this: &Discriminant) -> &core::mem::Discriminant<T> {
     unsafe {
         &*if small_discriminant::<T>() {
             this.data.as_ptr().cast::<core::mem::Discriminant<T>>()


### PR DESCRIPTION
I think the compiler can figure out some optimizations/inlining with this.

[as_ref](https://github.com/dtolnay/erased-discriminant/blob/dc5e6e674c66beb1b8dac6275ce1c696052586c3/src/lib.rs#L92) can also be made *const* if we bump MSRV to `1.59`, required for [as_ptr](https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#method.as_ptr) and [assume_init](https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#method.assume_init)